### PR TITLE
POSIX shebang

### DIFF
--- a/cgi-bin/resize
+++ b/cgi-bin/resize
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Content-type: text/html"
 echo ""

--- a/cgi-bin/terminal
+++ b/cgi-bin/terminal
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Content-type: text/html"
 echo ""

--- a/websocket.sh
+++ b/websocket.sh
@@ -33,7 +33,7 @@ is_packet()
   echo -n "$1" | grep -q -e $(printf '\x81') -e $(printf '\x82')
 }
 
-# read N bytes from pipe and convert to unsigned decimal 1-byte units (space seporated)
+# read N bytes from pipe and convert to unsigned decimal 1-byte units (space separated)
 read_dec()
 {
   dd bs=$1 count=1 2>/dev/null | od -A n -t u1 -w$1
@@ -111,7 +111,7 @@ ws_server()
       # decoding byte: byte ^ encoding_bytes[i % 4]
       let byte=byte^$(get_arg $(($i % 4 + 3)) $header)
       printf "\x$(printf '%02x' $byte)"
-      let i=i+1
+      i=$((i + 1))
     done
   done | $WS_SHELL 2>&1 | ws_send
 }

--- a/websocket.sh
+++ b/websocket.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # websocket.sh
 # (C) 2016-2018 Anton Skshidlevsky <meefik@gmail.com>, MIT
 # The cross platform WebSocket implementation for SH.


### PR DESCRIPTION
All scripts starts from shebang !/bin/bash that requires bash but it looks like the scripts may work on ash in busybox. To make it working on BB we should change the shebang to POSIX like /bin/sh
I checked with shellcheck and it seems that all should work:
1. Open the script in IntelliJ Idea/Goland\CLion or any other JetBrains ide
2. IntelliJ will recommend you to install chellcheck plugin
3. Then change shebang to `/bin/ash` and now shellcheck will analyze all script for compliance with Ash
4. But do not commit the change because not all platforms has /bin/ash (i.e. Ubuntu has /bin/dash). This change only to tell shellcheck which dialect should be supported.

Almost everything looks like it will work with Ash but there is a lot of other minor warnings. One of them I fixed in a separate commit.
Please check those warning too: some of them may be a potential bug.

Thank you for your work